### PR TITLE
Apply unified brutalist theming across hub and tools

### DIFF
--- a/3_d_color_space_organizer_collapsible_legend_updated_html.html
+++ b/3_d_color_space_organizer_collapsible_legend_updated_html.html
@@ -4,45 +4,8 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>3D Color‑Space Organizer — RGB / HSV (no ML)</title>
-  <style>
-   :root { --bg:#ffffff; --fg:#000000; --muted:#666666; --accent:#0077ff; --panel:#f9f9f9; }
-*{box-sizing:border-box}
-body{margin:0;background:var(--bg);color:var(--fg);font-family:ui-sans-serif,system-ui,-apple-system,Segoe UI,Inter,Roboto,Arial}
-header{position:sticky;top:0;z-index:5;backdrop-filter:blur(6px);background:rgba(255,255,255,0.9);border-bottom:1px solid #ddd}
-.bar{display:grid;grid-template-columns:1fr auto auto auto auto;gap:.75rem;padding:.9rem 1rem;align-items:center}
-.title{font-weight:700;letter-spacing:.2px}
-.controls{display:flex;gap:.5rem;align-items:center;flex-wrap:wrap}
-label{font-size:.85rem;color:var(--muted)}
-input[type=number],select{background:var(--panel);color:var(--fg);border:1px solid #ccc;border-radius:.4rem;padding:.4rem .6rem}
-input[type=number]{width:6rem}
-button{background:var(--accent);color:#fff;border:none;padding:.5rem .8rem;border-radius:.5rem;font-weight:600;cursor:pointer;box-shadow:0 2px 6px rgba(0,0,0,.15)}
-button.secondary{background:#f0f0f0;color:var(--fg);border:1px solid #ccc;box-shadow:none}
-.progress-wrap{height:.4rem;background:#eee;border-top:1px solid #ddd}
-.progress{height:100%;width:0;background:linear-gradient(90deg,#0077ff,#66bbff);transition:width .15s ease}
+  <link rel="stylesheet" href="theme.css">
 
-main{display:grid;grid-template-columns:1fr;gap:0}
-#view3d{height:64vh;min-height:420px;outline:1px solid #ddd}
-#stage2d{position:relative;margin:0 auto;border-radius:.5rem;background:#fafafa;outline:1px solid #ddd;width:min(95vw,1600px);aspect-ratio:1/1;overflow:hidden;display:none}
-.tile{position:absolute;border-radius:.25rem;overflow:hidden;box-shadow:0 1px 4px rgba(0,0,0,.15)}
-.tile img{width:100%;height:100%;object-fit:cover;display:block}
-
-/* Legend is now a collapsible <details> */
-.legend{padding:.6rem 1rem 1rem;color:var(--muted);font-size:.9rem;border-top:1px solid #eee}
-.legend>summary{cursor:pointer;user-select:none;font-weight:600;color:var(--fg);display:flex;align-items:center;gap:.5rem}
-.legend>summary::marker{content:""}
-.legend>summary:before{content:"▸";display:inline-block;transform:rotate(0deg);transition:transform .15s ease}
-.legend[open]>summary:before{transform:rotate(90deg)}
-.row{display:flex;gap:.5rem;align-items:center;flex-wrap:wrap;margin-top:.5rem}
-.pill{background:#f2f2f2;border:1px solid #ccc;color:var(--muted);padding:.2rem .5rem;border-radius:999px;font-size:.75rem}
-footer{padding:1rem;color:var(--muted);font-size:.8rem;text-align:center;border-top:1px solid #ddd}
-.kbd{border:1px solid #ccc;background:#f9f9f9;padding:.1rem .3rem;border-radius:.25rem;font-size:.8rem}
-
-/* Simple test summary badges */
-.tests{display:flex;gap:.5rem;justify-content:center;flex-wrap:wrap;margin:.5rem 0}
-.badge{font-size:.75rem;padding:.25rem .5rem;border-radius:999px;border:1px solid #ccc;background:#f5f5f5;color:#555}
-.badge.pass{border-color:#4caf50;background:#e8f5e9;color:#2e7d32}
-.badge.fail{border-color:#f44336;background:#fdecea;color:#c62828}
-  </style>
   <!-- Import map fixes bare specifiers so example add-ons can import "three" correctly -->
   <script type="importmap">
   {
@@ -53,7 +16,7 @@ footer{padding:1rem;color:var(--muted);font-size:.8rem;text-align:center;border-
   }
   </script>
 </head>
-<body>
+<body class="tool-3-d-color-space-organizer-collapsible-legend-updated-html">
   <header>
     <div class="bar">
       <div class="title">3D Color‑Space Organizer <span class="pill">RGB/HSV (no ML)</span></div>

--- a/audio_spectrogram_tool.html
+++ b/audio_spectrogram_tool.html
@@ -3,28 +3,13 @@
 <head>
   <meta charset="UTF-8">
   <title>Audio Spectrogram Viewer</title>
-  <style>
-    body {
-      background: #111;
-      color: white;
-      font-family: sans-serif;
-      text-align: center;
-    }
-    canvas {
-      background: black;
-      margin: 10px 0;
-      border: 1px solid #444;
-      image-rendering: pixelated;
-    }
-    input[type="file"] {
-      margin-top: 10px;
-    }
-  </style>
+  <link rel="stylesheet" href="theme.css">
+
 </head>
-<body>
-  <div id="sidebar" style="position: fixed; top: 0; left: 0; bottom: 0; width: 280px; background: #222; color: #ccc; padding: 1em; font-size: 0.9em; font-family: sans-serif; text-align: left; overflow-y: auto; display: none; z-index: 10;">
-    <button onclick="document.getElementById('sidebar').style.display='none'" style="float: right; margin-bottom: 0.5em; background: #444; color: white; border: none; padding: 0.3em 0.6em; cursor: pointer;">×</button>
-    <h2 style="margin-top: 2em;">Instructions</h2>
+<body class="tool-audio-spectrogram-tool">
+  <div id="sidebar">
+    <button class="sidebar-close" onclick="document.getElementById('sidebar').style.display='none'">×</button>
+    <h2>Instructions</h2>
     <ol>
       <li>Upload an audio file using the file input.</li>
       <li>The spectrogram will render the full audio length.</li>
@@ -32,9 +17,9 @@
       <li>Hold <code>Option</code> (or <code>Alt</code>) and drag the selection to duplicate it.</li>
       <li>Click <em>Resynthesize Audio</em> to play the modified audio.</li>
     </ol>
-    <p style="margin-top: 1em; font-style: italic;">Time runs left to right. Frequencies are low at the bottom, high at the top.</p>
+    <p class="sidebar-note">Time runs left to right. Frequencies are low at the bottom, high at the top.</p>
   </div>
-  <button onclick="document.getElementById('sidebar').style.display='block'" style="position: fixed; top: 10px; left: 10px; z-index: 11; background: #444; color: white; border: none; padding: 0.4em 0.8em; cursor: pointer;">❔ Help</button>
+  <button class="help-button" onclick="document.getElementById('sidebar').style.display='block'">❔ Help</button>
   <h1>Audio Spectrogram Viewer</h1>
   
   <input type="file" id="audioFile" accept="audio/*"><br>

--- a/brutalist_mind_map_scaled.html
+++ b/brutalist_mind_map_scaled.html
@@ -3,42 +3,10 @@
 <head>
   <meta charset="UTF-8">
   <title>Brutalist Mind Map Tool</title>
-  <style>
-    html, body {
-      margin: 0;
-      padding: 0;
-      background: white;
-      color: black;
-      font-family: monospace;
-      overflow: hidden;
-    }
-    canvas {
-      display: block;
-    }
-    #ui {
-      position: fixed;
-      top: 10px;
-      left: 10px;
-      background: white;
-      border: 1px solid black;
-      padding: 5px;
-      z-index: 10;
-    }
-    button, input[type=number] {
-      margin-right: 5px;
-      background: white;
-      color: black;
-      border: 1px solid black;
-      font-size: 12px;
-      cursor: pointer;
-    }
-    label {
-      margin-right: 5px;
-      font-size: 12px;
-    }
-  </style>
+  <link rel="stylesheet" href="theme.css">
+
 </head>
-<body>
+<body class="tool-brutalist-mind-map-scaled">
   <div id="ui">
     <label>Aspect X: <input type="number" id="aspectX" value="1" step="0.1" onchange="updateAspect()"></label>
     <label>Aspect Y: <input type="number" id="aspectY" value="1" step="0.1" onchange="updateAspect()"></label>

--- a/chisel_tip_pen_drawing_tool_standalone_html.html
+++ b/chisel_tip_pen_drawing_tool_standalone_html.html
@@ -4,45 +4,10 @@
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <title>Chisel‑Tip Pen — Standalone</title>
-<style>
-  :root{
-    --bg:#111417; --panel:#1b2026; --panel-2:#151a1f; --text:#e7edf3; --muted:#9db0c4; --accent:#5bb6ff;
-    --btn:#222933; --btn-hover:#2a3340; --danger:#ff6b6b; --ok:#58d68d; --grid:#1f2530;
-  }
-  *{box-sizing:border-box}
-  html,body{height:100%}
-  body{margin:0; background:var(--bg); color:var(--text); font:14px/1.4 system-ui, -apple-system, Segoe UI, Roboto, Inter, Arial, sans-serif;}
-  .app{display:grid; grid-template-columns: 320px 1fr; grid-template-rows:auto 1fr; height:100vh}
-  header{grid-column:1/3; padding:10px 12px; display:flex; gap:10px; align-items:center; background:linear-gradient(180deg,var(--panel),var(--panel-2)); border-bottom:1px solid #0d1117; position:sticky; top:0; z-index:3}
-  header h1{font-size:14px; margin:0; letter-spacing:.02em; color:var(--muted)}
-  .toolbar{display:flex; gap:8px; flex-wrap:wrap; align-items:center}
-  .side{padding:12px; background:var(--panel); border-right:1px solid #0d1117; overflow:auto}
-  .group{background:var(--panel-2); border:1px solid #0d1117; border-radius:12px; padding:10px; margin-bottom:10px}
-  .group h3{margin:0 0 8px; font-size:12px; color:var(--muted); font-weight:600; text-transform:uppercase; letter-spacing:.08em}
-  label{display:grid; grid-template-columns: 1fr auto; gap:8px; align-items:center; margin:6px 0}
-  input[type="range"]{width:180px}
-  input[type="number"]{width:72px; background:#0f141a; color:var(--text); border:1px solid #0d1117; padding:4px 6px; border-radius:8px}
-  input[type="checkbox"]{transform:translateY(1px)}
-  .row{display:flex; gap:8px; align-items:center; flex-wrap:wrap}
-  .btn{border:1px solid #0d1117; background:var(--btn); color:var(--text); padding:8px 10px; border-radius:10px; cursor:pointer}
-  .btn:hover{background:var(--btn-hover)}
-  .btn.eraser{border-color:#2b2b2b}
-  .btn.danger{background:#2a1b1b; border-color:#3b2222}
-  .btn.primary{outline:1px solid #2b3642}
-  .swatch{width:30px; height:30px; border-radius:8px; border:1px solid #0d1117; overflow:hidden}
-  #canvasWrap{position:relative; background:var(--bg)}
-  canvas{display:block; width:100%; height:100%; background:transparent; cursor: crosshair}
-  .overlay{position:absolute; inset:0; pointer-events:none}
-  .grid{position:absolute; inset:0; background-size: 32px 32px, 8px 8px; background-image:
-        linear-gradient(var(--grid) 1px, transparent 1px),
-        linear-gradient(90deg, var(--grid) 1px, transparent 1px);
-        pointer-events:none; z-index:0; opacity:.6}
-  .readout{position:absolute; right:10px; bottom:10px; background:rgba(0,0,0,.5); padding:6px 8px; border-radius:8px; font:12px/1.2 ui-monospace, SFMono-Regular, Menlo, monospace; color:#cde}
-  .kbd{font:12px/1 ui-monospace, SFMono-Regular, Menlo, monospace; background:#10151b; border:1px solid #0d1117; padding:2px 5px; border-radius:6px}
-  .help{color:var(--muted); font-size:12px}
-</style>
+<link rel="stylesheet" href="theme.css">
+
 </head>
-<body>
+<body class="tool-chisel-tip-pen-drawing-tool-standalone-html">
   <div class="app">
     <header>
       <h1>Chisel‑Tip Pen</h1>
@@ -60,7 +25,7 @@
     <aside class="side">
       <div class="group">
         <h3>Nib</h3>
-        <div class="row" style="gap:12px">
+        <div class="row row-spaced">
           <div>
             <div class="help">Color</div>
             <input id="color" type="color" value="#000000" />

--- a/graded_game_of_life.html
+++ b/graded_game_of_life.html
@@ -3,94 +3,10 @@
 <head>
   <meta charset="UTF-8">
   <title>Graded Game of Life</title>
-  <style>
-    :root {
-      --bg: #121212;
-      --panel: #1f1f1f;
-      --accent: #00ffe7;
-      --text: #f0f0f0;
-      --slider-bg: #333;
-      --slider-thumb: var(--accent);
-      --font: 'Segoe UI', sans-serif;
-    }
-    body {
-      margin: 0;
-      background: var(--bg);
-      font-family: var(--font);
-      color: var(--text);
-      display: flex;
-      flex-direction: column;
-      align-items: center;
-    }
-    canvas {
-      background: black;
-      cursor: crosshair;
-      box-shadow: 0 0 20px rgba(0,0,0,0.8);
-      margin: 1.5rem 0;
-      border-radius: 8px;
-    }
-    .controls {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-      gap: 1.5rem;
-      width: 95%;
-      max-width: 1200px;
-      background: var(--panel);
-      padding: 2rem;
-      border-radius: 12px;
-      box-shadow: 0 0 20px rgba(0,0,0,0.4);
-    }
-    h4 {
-      color: var(--accent);
-      margin-top: 0;
-      font-weight: 500;
-      font-size: 1.1rem;
-    }
-    .control-group {
-      margin-bottom: 1rem;
-    }
-    label {
-      font-size: 0.9rem;
-      margin-bottom: 0.3rem;
-      display: block;
-    }
-    input[type="range"] {
-      width: 100%;
-      background-color: var(--slider-bg);
-      accent-color: var(--slider-thumb);
-    }
-    input[type="text"], button {
-      padding: 0.4rem 0.6rem;
-      border: none;
-      border-radius: 6px;
-      font-size: 0.9rem;
-      font-family: var(--font);
-    }
-    input[type="text"] {
-      background: #333;
-      color: var(--text);
-      width: 300px;
-    }
-    button {
-      background: var(--accent);
-      color: #000;
-      font-weight: bold;
-      margin: 0 0.5rem 0.5rem 0;
-      cursor: pointer;
-      transition: background 0.3s;
-    }
-    button:hover {
-      background: #00ccbb;
-    }
-    .button-row {
-      margin-bottom: 1rem;
-      display: flex;
-      flex-wrap: wrap;
-      justify-content: center;
-    }
-  </style>
+  <link rel="stylesheet" href="theme.css">
+
 </head>
-<body>
+<body class="tool-graded-game-of-life">
   <div class="controls">
     <div>
       <h4>Birth</h4>
@@ -143,7 +59,7 @@
     </div>
   </div>
 
-  <canvas id="lifeCanvas" width="400" height="400" style="width: 800px; height: 800px; image-rendering: pixelated;"></canvas>
+  <canvas id="lifeCanvas" width="400" height="400"></canvas>
   <div class="button-row">
     <button id="togglePlay">Pause</button>
     <button id="clearButton">Clear</button>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,159 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Arlo Tools Hub</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="stylesheet" href="theme.css">
+
+</head>
+<body class="tool-index">
+  <aside class="sidebar">
+    <h1><span>AT</span>Arlo Tools Hub</h1>
+    <p>Browse, search, and launch any of the bundled experiments. Pick a tool to load it here or open it directly in a new tab.</p>
+    <label class="search-wrapper">
+      <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M10.5 3a7.5 7.5 0 015.977 12.072l3.226 3.225a1 1 0 01-1.414 1.415l-3.226-3.226A7.5 7.5 0 1110.5 3zm0 2a5.5 5.5 0 100 11 5.5 5.5 0 000-11z"/></svg>
+      <span class="sr-only">Search tools</span>
+      <input id="search" type="search" placeholder="Search tools..." autocomplete="off">
+    </label>
+    <div id="tool-list" role="listbox" aria-label="Available tools"></div>
+  </aside>
+  <main>
+    <div class="toolbar">
+      <h2 id="tool-name">Choose a tool</h2>
+      <a id="open-new-tab" href="#" target="_blank" rel="noopener">Open in new tab</a>
+    </div>
+    <div class="frame-container">
+      <iframe id="tool-frame" title="Selected tool" hidden></iframe>
+    </div>
+  </main>
+
+  <script>
+    const tools = [
+      { name: "3D Color Space Organizer", file: "3_d_color_space_organizer_collapsible_legend_updated_html.html" },
+      { name: "Audio Spectrogram Tool", file: "audio_spectrogram_tool.html" },
+      { name: "Brutalist Mind Map", file: "brutalist_mind_map_scaled.html" },
+      { name: "Chisel Tip Pen Drawing Tool", file: "chisel_tip_pen_drawing_tool_standalone_html.html" },
+      { name: "Graded Game of Life", file: "graded_game_of_life.html" },
+      { name: "Less Circle Centric Fractal", file: "less-circle-centric-fractal (1).html" },
+      { name: "Lissajous Figure Grid", file: "lissajous_figure_grid.html" },
+      { name: "Medieval Border Generator", file: "medieval_border_generator_geometric_tiling_v_2.html" },
+      { name: "MIDI → Neumes Converter", file: "midi_→_neumes_converter_single_file_html.html" },
+      { name: "Particle Tree Zoom & Scroll", file: "particle_tree_zoom_scroll.html" },
+      { name: "Pixel Row Glitcher", file: "pixel_row_glitcher.html" },
+      { name: "Random I Heart", file: "random_i_heart.html" },
+      { name: "Recursive Vector Fractal Lab", file: "recursive_vector_fractal_lab_standalone_html (2).html" },
+      { name: "Spectrogram Glitch Posteﬀects", file: "spectrogram_glitch_posteffects (1).html" },
+      { name: "Square Tiling Tool", file: "square_tiling_tool_svg_import_export.html" }
+    ];
+
+    const toolList = document.getElementById("tool-list");
+    const searchInput = document.getElementById("search");
+    const iframe = document.getElementById("tool-frame");
+    const toolName = document.getElementById("tool-name");
+    const openNewTab = document.getElementById("open-new-tab");
+
+    const createIcon = () => {
+      const svgNS = "http://www.w3.org/2000/svg";
+      const icon = document.createElementNS(svgNS, "svg");
+      icon.setAttribute("viewBox", "0 0 24 24");
+      const path = document.createElementNS(svgNS, "path");
+      path.setAttribute("d", "M13.172 11l-3.95-3.95a1 1 0 011.414-1.414l5.657 5.657a1 1 0 010 1.414l-5.657 5.657a1 1 0 11-1.414-1.414L13.172 13H4a1 1 0 110-2h9.172z");
+      icon.appendChild(path);
+      return icon;
+    };
+
+    let activeButton = null;
+
+    const toUrl = (file) => encodeURI(file).replace(/#/g, "%23");
+
+    const selectTool = (tool, button) => {
+      if (button === activeButton) {
+        return;
+      }
+
+      if (activeButton) {
+        activeButton.classList.remove("active");
+        activeButton.setAttribute("aria-selected", "false");
+      }
+
+      activeButton = button;
+      button.classList.add("active");
+      button.setAttribute("aria-selected", "true");
+      const url = toUrl(tool.file);
+      iframe.src = url;
+      iframe.hidden = false;
+      toolName.textContent = tool.name;
+      openNewTab.href = url;
+    };
+
+    tools.forEach((tool, index) => {
+      const button = document.createElement("button");
+      button.type = "button";
+      button.className = "tool-button";
+      button.setAttribute("role", "option");
+      button.dataset.file = tool.file;
+      button.dataset.name = tool.name.toLowerCase();
+
+      const label = document.createElement("span");
+      label.textContent = tool.name;
+
+      button.appendChild(label);
+      button.appendChild(createIcon());
+
+      button.addEventListener("click", () => selectTool(tool, button));
+      button.addEventListener("keydown", (event) => {
+        if (event.key === "Enter" || event.key === " ") {
+          event.preventDefault();
+          selectTool(tool, button);
+        }
+      });
+
+      toolList.appendChild(button);
+
+      if (index === 0) {
+        selectTool(tool, button);
+      }
+    });
+
+    const updateFilter = () => {
+      const query = searchInput.value.trim().toLowerCase();
+      let visibleButtons = 0;
+
+      toolList.querySelectorAll(".tool-button").forEach((button) => {
+        const matches = button.dataset.name.includes(query);
+        button.style.display = matches ? "flex" : "none";
+        if (matches) {
+          visibleButtons += 1;
+        }
+      });
+
+      if (visibleButtons === 0) {
+        iframe.hidden = true;
+        iframe.removeAttribute("src");
+        toolName.textContent = "No tools match";
+        openNewTab.href = "#";
+        if (activeButton) {
+          activeButton.classList.remove("active");
+          activeButton.setAttribute("aria-selected", "false");
+        }
+        activeButton = null;
+        return;
+      }
+
+      iframe.hidden = false;
+
+      if (!activeButton || activeButton.style.display === "none") {
+        const firstVisible = Array.from(toolList.querySelectorAll(".tool-button")).find((button) => button.style.display !== "none");
+        if (firstVisible) {
+          const file = firstVisible.dataset.file;
+          const tool = tools.find((item) => item.file === file);
+          selectTool(tool, firstVisible);
+        }
+      }
+    };
+
+    searchInput.addEventListener("input", updateFilter);
+  </script>
+</body>
+</html>

--- a/less-circle-centric-fractal (1).html
+++ b/less-circle-centric-fractal (1).html
@@ -4,38 +4,10 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Dynamic Sine Wave Fractal Maker</title>
-  <style>
-    body {
-      display: flex;
-      flex-direction: column;
-      align-items: center;
-      font-family: Arial, sans-serif;
-    }
+  <link rel="stylesheet" href="theme.css">
 
-    canvas {
-      border: 1px solid black;
-      margin: 20px 0;
-    }
-
-    .controls {
-      display: flex;
-      flex-wrap: wrap;
-      gap: 10px;
-      justify-content: center;
-    }
-
-    .control-group {
-      display: flex;
-      flex-direction: column;
-      align-items: center;
-    }
-
-    .control-group label {
-      margin-bottom: 5px;
-    }
-  </style>
 </head>
-<body>
+<body class="tool-less-circle-centric-fractal-1">
   <h1>Dynamic Sine Wave Fractal Maker</h1>
   <canvas id="fractalCanvas" width="800" height="600"></canvas>
   <div class="controls">

--- a/lissajous_figure_grid.html
+++ b/lissajous_figure_grid.html
@@ -3,82 +3,10 @@
 <head>
   <meta charset="UTF-8" />
   <title>Lissajous Figure Table</title>
-  <style>
-    html, body {
-      margin: 0;
-      padding: 0;
-      height: 100%;
-      width: 100%;
-      font-family: sans-serif;
-      background: #f0f0f0;
-      overflow: hidden;
-    }
-    body {
-      display: flex;
-      flex-direction: row;
-    }
-    #sidebar {
-      width: 200px;
-      background: #fff;
-      padding: 1rem;
-      box-shadow: -2px 0 5px rgba(0, 0, 0, 0.1);
-      display: flex;
-      flex-direction: column;
-      justify-content: center;
-      align-items: center;
-      gap: 1rem;
-    }
-    #table-container {
-      flex: 1;
-      display: flex;
-      justify-content: center;
-      align-items: center;
-      padding: 1rem;
-    }
-    #lissajous-table {
-      border-collapse: collapse;
-      width: 90vmin;
-      height: 90vmin;
-      table-layout: fixed;
-    }
-    th, td {
-      border: 1px solid #ccc;
-      padding: 0;
-      background: #fff;
-    }
-    th {
-      background: #e0e0e0;
-      font-size: 0.6rem;
-      text-align: center;
-    }
-    canvas {
-      width: 100%;
-      height: auto;
-      aspect-ratio: 1 / 1;
-      display: block;
-    }
-    h1 {
-      margin: 0 0 1rem 0;
-      font-size: 1.1rem;
-    }
-    th.corner {
-      width: 2em;
-      height: 2em;
-      min-width: 2em;
-      min-height: 2em;
-      padding: 0;
-    }
-    th.row-header {
-      width: 2em;
-      text-align: center;
-    }
-    label {
-      font-size: 0.9rem;
-      text-align: center;
-    }
-  </style>
+  <link rel="stylesheet" href="theme.css">
+
 </head>
-<body>
+<body class="tool-lissajous-figure-grid">
   <div id="table-container">
     <table id="lissajous-table"></table>
   </div>

--- a/medieval_border_generator_geometric_tiling_v_2.html
+++ b/medieval_border_generator_geometric_tiling_v_2.html
@@ -4,26 +4,10 @@
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width,initial-scale=1" />
 <title>Medieval Border Generator — Complete Styles</title>
-<style>
-  :root{--paper:#f6f1e6;--card:#fff;--ink:#121212;--fill:#ffffff}
-  *{box-sizing:border-box}
-  body{margin:0;background:var(--paper);font:14px/1.25 ui-sans-serif,system-ui,Segoe UI,Roboto,Helvetica,Arial;color:#222}
-  header{position:sticky;top:0;z-index:2;background:#fff9;border-bottom:1px solid #ddd;padding:12px;display:flex;gap:10px;flex-wrap:wrap;align-items:end}
-  header h1{font-size:16px;margin:0 12px 0 0}
-  label{display:inline-grid;gap:6px;font-size:12px}
-  input,select,button{padding:8px 10px;border:1px solid #bbb;border-radius:8px;background:#fff}
-  button{cursor:pointer}
-  main{display:grid;grid-template-columns:340px 1fr;gap:12px;padding:12px}
-  .panel{background:var(--card);border:1px solid #ddd;border-radius:12px;padding:12px}
-  .tile{width:100%}
-  .preview{height:92px;width:100%;border-radius:10px;display:flex;align-items:center;justify-content:center;background:repeating-linear-gradient(90deg,#f7f3ea,#f7f3ea 60px,#efe9dc 60px,#efe9dc 120px);overflow:hidden}
-  .strip{height:64px}
-  .muted{opacity:.7}
-  .swatch{display:inline-flex;gap:6px;align-items:center}
-  .swatch input{width:40px;height:34px;padding:0;border-radius:6px}
-</style>
+<link rel="stylesheet" href="theme.css">
+
 </head>
-<body>
+<body class="tool-medieval-border-generator-geometric-tiling-v-2">
   <header>
     <h1>Medieval Border Generator — <em>Complete Styles</em></h1>
     <label>Seed
@@ -60,8 +44,8 @@
     <section class="panel">
       <strong>Preview (repeating the tile)</strong>
       <div class="preview"><canvas id="strip1" class="strip" width="2000" height="64"></canvas></div>
-      <div class="preview" style="margin-top:8px"><canvas id="strip2" class="strip" width="2000" height="64"></canvas></div>
-      <div class="preview" style="margin-top:8px"><canvas id="strip3" class="strip" width="2000" height="64"></canvas></div>
+      <div class="preview"><canvas id="strip2" class="strip" width="2000" height="64"></canvas></div>
+      <div class="preview"><canvas id="strip3" class="strip" width="2000" height="64"></canvas></div>
     </section>
   </main>
 

--- a/midi_→_neumes_converter_single_file_html.html
+++ b/midi_→_neumes_converter_single_file_html.html
@@ -4,30 +4,10 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>MIDI → Neumes (Square‑Note) — Single‑File HTML</title>
-  <style>
-    :root { --bg:#fafafa; --fg:#111; --muted:#666; --border:#ddd; --accent:#ef4444; }
-    * { box-sizing: border-box; }
-    body { margin: 0; font: 15px/1.4 system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif; color: var(--fg); background: var(--bg); }
-    header { padding: 20px 16px 8px; max-width: 1200px; margin: 0 auto; }
-    h1 { margin: 0 0 6px; font-size: 22px; }
-    p.lede { margin: 0 0 16px; color: var(--muted); }
-    .wrap { max-width: 1200px; margin: 0 auto; padding: 0 16px 32px; }
-    .controls { display: grid; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); gap: 10px; margin-bottom: 12px; }
-    .card { background: #fff; border: 1px solid var(--border); border-radius: 14px; padding: 10px 12px; display: flex; align-items: center; gap: 8px; }
-    label { font-size: 13px; color: var(--fg); }
-    select, input[type="file"], button, input[type="range"] { font: inherit; }
-    select { padding: 6px 8px; border: 1px solid var(--border); border-radius: 10px; background: white; }
-    button { padding: 8px 10px; border: 1px solid var(--border); background: #fff; border-radius: 12px; cursor: pointer; }
-    button:hover { box-shadow: 0 1px 6px rgba(0,0,0,.08); }
-    .alert { border: 1px solid #fecaca; background: #fff1f2; color: #991b1b; padding: 10px 12px; border-radius: 10px; margin: 8px 0 12px; }
-    #neumes-svg-container { background: #fff; border: 1px solid var(--border); border-radius: 14px; padding: 10px; overflow: auto; min-height: 160px; }
-    details { margin-top: 10px; color: var(--muted); }
-    details > summary { cursor: pointer; color: #222; }
-    .spacer { flex: 1; }
-    .pill { padding: 2px 8px; border: 1px solid var(--border); border-radius: 999px; font-size: 12px; color: #333; }
-  </style>
+  <link rel="stylesheet" href="theme.css">
+
 </head>
-<body>
+<body class="tool-midi-neumes-converter-single-file-html">
   <header>
     <h1>MIDI → Neumes (square‑note) Converter</h1>
     <p class="lede">Upload a MIDI file, choose a melodic track, and render approximate medieval chant neumes (punctum, podatus, clivis, torculus, porrectus, scandicus, climacus) on a 4‑line staff. Export the SVG — and now, <strong>play it back with a moving cursor</strong>.</p>
@@ -60,22 +40,22 @@
         <button id="play" disabled>▶︎ Play</button>
         <button id="stop" disabled>■ Stop</button>
         <span class="pill" id="tempo">Tempo: —</span>
-        <label for="wave" style="margin-left:8px">Wave</label>
+        <label for="wave" class="transport-label">Wave</label>
         <select id="wave">
           <option value="sine">sine</option>
           <option value="triangle">triangle</option>
           <option value="square">square</option>
           <option value="sawtooth">sawtooth</option>
         </select>
-        <label for="volume" style="margin-left:8px">Vol</label>
+        <label for="volume" class="transport-label">Vol</label>
         <input id="volume" type="range" min="0" max="1" step="0.01" value="0.3" />
       </div>
     </section>
 
-    <div id="error" class="alert" style="display:none"></div>
+    <div id="error" class="alert"></div>
 
     <div id="neumes-svg-container">
-      <div style="padding:16px; color: var(--muted);">Upload a MIDI file to see the rendering here.</div>
+      <div class="placeholder muted">Upload a MIDI file to see the rendering here.</div>
     </div>
 
     <details>
@@ -296,7 +276,7 @@
     mono = toMonophonic(selTrack.notes, policy);
     groups = groupNeumes(mono, parsed.ticksPerBeat);
     centerPitch = computePitchCenter(mono);
-    if (groups.length === 0){ svgContainer.innerHTML = '<div style="padding:16px;color:#666">No melodic content detected on this track.</div>'; dlBtn.disabled = true; playBtn.disabled = true; stopBtn.disabled = true; return; }
+    if (groups.length === 0){ svgContainer.innerHTML = '<div class="placeholder muted">No melodic content detected on this track.</div>'; dlBtn.disabled = true; playBtn.disabled = true; stopBtn.disabled = true; return; }
     renderInfo = renderNeumesSVG({ container: svgContainer, groups, centerPitch, options: { labelNeumes } });
     dlBtn.disabled = false; playBtn.disabled = false; stopBtn.disabled = false;
 
@@ -413,7 +393,7 @@
 
   // Event wiring
   fileInput.addEventListener('change', ()=>{
-    setError(''); dlBtn.disabled = true; svgContainer.innerHTML='<div style="padding:16px;color:#666">Parsing…</div>';
+    setError(''); dlBtn.disabled = true; svgContainer.innerHTML='<div class="placeholder muted">Parsing…</div>';
     const f = fileInput.files && fileInput.files[0];
     if (!f){ setError('No file selected'); svgContainer.innerHTML=''; return; }
     const reader = new FileReader();

--- a/particle_tree_zoom_scroll.html
+++ b/particle_tree_zoom_scroll.html
@@ -3,15 +3,10 @@
 <head>
   <meta charset="UTF-8">
   <title>Particle Tree Generator</title>
-  <style>
-    html, body { margin: 0; padding: 0; background: white; color: black; font-family: monospace; overflow: hidden; }
-    canvas { display: block; background: white; border: 2px solid black; }
-    .ui { position: absolute; top: 10px; left: 10px; background: white; border: 2px solid black; padding: 10px; z-index: 10; }
-    label, button { display: block; margin-bottom: 6px; }
-    input[type=range], input[type=checkbox] { width: 100%; }
-  </style>
+  <link rel="stylesheet" href="theme.css">
+
 </head>
-<body>
+<body class="tool-particle-tree-zoom-scroll">
   <canvas id="treeCanvas"></canvas>
   <div class="ui">
     <label>Curviness Threshold: <input type="range" id="curviness" min="0.1" max="3.14" step="0.01" value="1.57"></label>

--- a/pixel_row_glitcher.html
+++ b/pixel_row_glitcher.html
@@ -3,25 +3,10 @@
 <head>
   <meta charset="UTF-8" />
   <title>Row and Column Glitch Image Processor</title>
-  <style>
-    body {
-      background: #111;
-      color: white;
-      font-family: sans-serif;
-      text-align: center;
-      padding: 20px;
-    }
-    canvas {
-      border: 1px solid #444;
-      display: block;
-      margin: 1rem auto;
-    }
-    input[type="range"] {
-      width: 300px;
-    }
-  </style>
+  <link rel="stylesheet" href="theme.css">
+
 </head>
-<body>
+<body class="tool-pixel-row-glitcher">
   <h1>Row and Column Glitch Image Processor</h1>
   <input type="file" id="imageLoader" accept="image/*" />
   <br><br>

--- a/random_i_heart.html
+++ b/random_i_heart.html
@@ -4,34 +4,10 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Random “I ♥” Generator</title>
-  <style>
-    :root { --red:#e4002b; }
-    *{box-sizing:border-box;}
-    body{margin:0;display:flex;flex-direction:column;align-items:center;font-family:Helvetica,Arial,sans-serif;background:#fff;color:#000;}
-    #design{text-align:center;line-height:1.05;margin-top:1rem;}
-    #topText{font-size:12rem;letter-spacing:-.05em;white-space:nowrap;}
-    .heart{width:1em;height:1em;display:inline-block;vertical-align:-0.12em;}
-    .heart path{fill:var(--red);}
-    #bottomCanvas{display:block;margin:-0.35em auto 0 auto;}
+  <link rel="stylesheet" href="theme.css">
 
-    /* Toggle button */
-    #toggleFilters{margin:1rem 0;padding:.5rem 1rem;font-size:1rem;border:2px solid #000;background:#fff;cursor:pointer;}
-    #toggleFilters:hover{background:#f2f2f2;}
-
-    /* Controls */
-    #controls{max-width:700px;padding:1rem 0;display:none;} /* hidden by default */
-    #controls.open{display:block;}
-    fieldset{border:1px solid #0003;padding:1rem;margin:0;}
-    legend{padding:0 .5rem;}
-    label{display:inline-flex;align-items:center;margin:0 .8rem .4rem 0;user-select:none;}
-    label input{margin-right:.3rem;}
-
-    #generate{margin:1.5rem 0 2rem;padding:.75rem 1.5rem;font-size:1rem;border:2px solid #000;background:#fff;cursor:pointer;}
-    #generate:hover{background:#f2f2f2;}
-    #status{font-size:.9rem;color:#555;}
-  </style>
 </head>
-<body>
+<body class="tool-random-i-heart">
   <!-- Toggle button -->
   <button id="toggleFilters" aria-expanded="false">Show Filters ▾</button>
 

--- a/recursive_vector_fractal_lab_standalone_html (2).html
+++ b/recursive_vector_fractal_lab_standalone_html (2).html
@@ -4,53 +4,10 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Recursive Vector Fractal Lab — Standalone</title>
-  <style>
-    :root { --bg: #ffffff; --fg: #111; --panel: #fff; --border:#e5e7eb; --indigo:#6366f1; }
-    html,body{ height:100%; margin:0; font:14px/1.4 ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, "Apple Color Emoji", "Segoe UI Emoji"; color: var(--fg); }
-    .app{ display:flex; flex-direction:column; height:100%; }
-    header{ position:sticky; top:0; z-index:10; display:flex; align-items:center; gap:.5rem; padding:.5rem 1rem; background:rgba(255,255,255,.7); backdrop-filter: blur(6px); border-bottom:1px solid var(--border); }
-    h1{ font-size:18px; font-weight:600; margin:0; }
-    .spacer{ flex:1; }
-    .btn{ font-size:13px; padding:.25rem .5rem; border:1px solid var(--border); background:#fff; border-radius:12px; box-shadow: 0 1px 0 rgba(0,0,0,.04); cursor:pointer; }
-    .btn:hover{ background:#f8fafc; }
-    .btn.primary{ background:#4f46e5; border-color:#4338ca; color:#fff; }
-    .btn.danger{ background:#fef2f2; color:#dc2626; }
-    .btn.active{ background:#4f46e5; color:#fff; border-color:#4338ca; }
-    .grid{ display:grid; grid-template-columns: 1fr 320px; min-height:0; flex:1; }
-    .left{ position:relative; background:var(--bg); }
-    .wrap{ position:absolute; inset:0; }
-    canvas, svg.overlay{ position:absolute; inset:0; display:block; }
-    .right{ border-left:1px solid var(--border); background:var(--panel); overflow:auto; }
-    section{ padding:12px; border-bottom:1px solid var(--border); }
-    .section-title{ font-size:12px; font-weight:600; letter-spacing:.06em; text-transform:uppercase; color:#6b7280; margin:0 0 8px; }
-    .row{ display:flex; align-items:center; justify-content:space-between; gap:.5rem; padding:.25rem 0; }
-    .row input[type="number"]{ width:90px; }
-    .cols2{ display:grid; grid-template-columns: repeat(2,minmax(0,1fr)); gap:.5rem; font-size:13px; }
-    .muted{ color:#6b7280; font-size:12px; }
-    .divider{ width:1px; height:24px; background:var(--border); margin:0 .5rem; }
-    .shape-card{ border:1px solid var(--border); border-radius:12px; padding:8px; box-shadow:0 1px 0 rgba(0,0,0,.04); }
-    .ring{ outline: 2px solid #4f46e5; }
-    .controls{ display:flex; gap:.5rem; }
-    input[type="range"]{ width:160px; }
-    label.inline{ display:flex; align-items:center; gap:.25rem; font-size:13px; }
-    .kbd{ font-family: ui-monospace, Menlo, Consolas, monospace; padding:0 4px; border:1px solid var(--border); border-radius:4px; background:#f8fafc; }
-    /* Responsive tweaks */
-    .right{ width: clamp(260px, 30vw, 380px); z-index: 11; }
-    .backdrop{ display:none; position:fixed; inset:0; background:rgba(0,0,0,.12); z-index: 9; }
-    header{ gap:.5rem; }
-    @media (max-width: 900px){
-      .grid{ grid-template-columns: 1fr; }
-      header{ flex-wrap: wrap; }
-      input[type="range"]{ width:100%; }
-      .divider{ display:none; }
-      .right{ position:fixed; top: var(--hdr,56px); right:0; bottom:0; width:min(100vw, 360px); transform: translateX(100%); transition: transform .25s ease; box-shadow: -8px 0 16px rgba(0,0,0,.08); }
-      body.panel-open .right{ transform: translateX(0); }
-      body.panel-open .backdrop{ display:block; }
-      .left{ min-height: calc(100vh - var(--hdr,56px)); }
-    }
-  </style>
+  <link rel="stylesheet" href="theme.css">
+
 </head>
-<body>
+<body class="tool-recursive-vector-fractal-lab-standalone-html-2">
 <div class="app">
   <header>
     <h1>Recursive Vector Fractal Lab</h1>
@@ -68,7 +25,7 @@
 
   <div class="grid">
     <div id="drawer-backdrop" class="backdrop"></div>
-    <div class="left" id="left" style="background: var(--bg)">
+    <div class="left" id="left">
       <div class="wrap" id="wrap">
         <canvas id="canvas"></canvas>
         <svg class="overlay" id="overlay"></svg>
@@ -88,14 +45,14 @@
 
       <section>
         <h2 class="section-title">Transforms</h2>
-        <button id="add-transform" class="btn primary" style="margin-bottom:6px">Add Transform</button>
+        <button id="add-transform" class="btn primary btn-stack">Add Transform</button>
         <div id="transforms"></div>
       </section>
 
       <section>
         <h2 class="section-title">Shapes</h2>
         <div id="shapes"></div>
-        <div class="muted" id="no-shapes" style="display:none">No shapes yet. Use the toolbar, or hold <span class="kbd">R</span>/<span class="kbd">C</span> then drag on canvas.</div>
+        <div class="muted" id="no-shapes">No shapes yet. Use the toolbar, or hold <span class="kbd">R</span>/<span class="kbd">C</span> then drag on canvas.</div>
       </section>
 
       <section>
@@ -103,21 +60,21 @@
         <div class="cols2">
           <label class="inline">BG <input id="bg" type="color" value="#ffffff"></label>
           <button id="center" class="btn">Center / 100%</button>
-          <label class="inline" style="grid-column:1 / -1"><input id="grid2" type="checkbox" checked> Show grid</label>
-          <label class="inline" style="grid-column:1 / -1"><input id="snap2" type="checkbox"> Snap to integer</label>
-          <div class="muted" style="grid-column:1 / -1">Zoom: <span id="zoomlabel">1.00</span> · Pan: <span id="panlabel">0, 0</span></div>
+          <label class="inline full-span"><input id="grid2" type="checkbox" checked> Show grid</label>
+          <label class="inline full-span"><input id="snap2" type="checkbox"> Snap to integer</label>
+          <div class="muted full-span">Zoom: <span id="zoomlabel">1.00</span> · Pan: <span id="panlabel">0, 0</span></div>
         </div>
       </section>
 
       <section>
         <h2 class="section-title">I/O</h2>
         <div class="controls">
-          <button id="export-png" class="btn" style="background:#059669;color:#fff;border-color:#047857">Export PNG</button>
-          <button id="export-json" class="btn" style="background:#111;color:#fff;border-color:#000">Export JSON</button>
-          <label class="btn" style="cursor:pointer">Import JSON <input id="import-json" type="file" accept="application/json" hidden></label>
+          <button id="export-png" class="btn success">Export PNG</button>
+          <button id="export-json" class="btn dark">Export JSON</button>
+          <label class="btn file-input">Import JSON <input id="import-json" type="file" accept="application/json" hidden></label>
           <button id="clear" class="btn danger">Clear</button>
         </div>
-        <p class="muted" style="margin-top:8px">Tips: Hold <b>R</b> or <b>C</b> and drag in Select to create shapes. Middle-mouse or hold Space + drag to pan. Ctrl/Cmd + Scroll to zoom. Arrow keys nudge selected shape. Enter to close polygon. Shift + drag on selected = rotate.</p>
+        <p class="muted tips">Tips: Hold <b>R</b> or <b>C</b> and drag in Select to create shapes. Middle-mouse or hold Space + drag to pan. Ctrl/Cmd + Scroll to zoom. Arrow keys nudge selected shape. Enter to close polygon. Shift + drag on selected = rotate.</p>
       </section>
     </div>
   </div>
@@ -548,7 +505,7 @@ function renderTransforms(){
   affines.forEach((A, i)=>{
     const el = document.createElement('div'); el.className='shape-card';
     el.innerHTML = `
-      <div class="row" style="margin-bottom:4px"><div class="muted">Branch ${i+1}</div>
+      <div class="row row-compact"><div class="muted">Branch ${i+1}</div>
         <div class="controls">
           <button class="btn" data-act="clone">Clone</button>
           <button class="btn danger" data-act="delete">Delete</button>
@@ -581,7 +538,7 @@ function renderShapes(){
           <button class="btn danger" data-act="delete">Delete</button>
         </div>
       </div>
-      <div class="cols2" style="margin-top:4px">
+      <div class="cols2 cols2-spaced">
         <label class="inline">Stroke <input type="color" data-k="stroke" value="${sh.stroke||'#111111'}"></label>
         <label class="inline">Fill <input type="color" data-k="fill" value="${sh.fill||'#000000'}"></label>
         <label class="inline">Width <input type="number" class="w-20" step="0.2" data-k="strokeWidth" value="${sh.strokeWidth||1}"></label>

--- a/spectrogram_glitch_posteffects (1).html
+++ b/spectrogram_glitch_posteffects (1).html
@@ -4,23 +4,12 @@
 <meta charset="UTF-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <title>Audio ⇄ Extreme‑Glitched Spectrogram</title>
-<style>
-  :root{color-scheme:dark;--bg:#111;--fg:#eee;--accent:#57f;--btn:#222;--btn-hover:#333;}
-  html,body{margin:0;padding:0;background:var(--bg);color:var(--fg);font-family:system-ui,sans-serif;}
-  main{display:grid;gap:1rem;padding:2rem;max-width:100vw;}
-  header{font-size:1.7rem;font-weight:700;line-height:1.2;}
-  #controls{display:flex;flex-wrap:wrap;gap:1rem;align-items:center;}
-  button,input[type="file"]{background:var(--btn);color:var(--fg);border:none;padding:.6rem 1rem;font-size:1rem;border-radius:.55rem;cursor:pointer;}
-  button:hover,input[type="file"]:hover{background:var(--btn-hover);}  
-  canvas{border:1px solid #444;max-width:100%;height:auto;background:#000;}
-  label{display:flex;align-items:center;gap:.4rem;font-size:.9rem;white-space:nowrap;cursor:pointer;}
-  input[type="range"]{accent-color:var(--accent);} 
-  footer{font-size:.8rem;opacity:.75;line-height:1.3;}
-</style>
+<link rel="stylesheet" href="theme.css">
+
 <!-- FFT lib -->
 <script src="https://cdn.jsdelivr.net/gh/corbanbrook/dsp.js@master/dsp.js"></script>
 </head>
-<body>
+<body class="tool-spectrogram-glitch-posteffects-1">
 <main>
   <header>Audio ⇄ Extreme‑Glitched Spectrogram Toy</header>
   <div id="controls">

--- a/square_tiling_tool_svg_import_export.html
+++ b/square_tiling_tool_svg_import_export.html
@@ -3,23 +3,10 @@
 <head>
   <meta charset="UTF-8" />
   <title>Greedy Square Fitting + SVG Import + Export</title>
-  <style>
-    :root { --ui: #111; }
-    html, body { height: 100%; }
-    body { margin: 0; background:#fff; font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial; }
-    #ui { position: fixed; top: 12px; left: 12px; background: rgba(255,255,255,.95); border:1px solid #000; padding:10px 12px; border-radius:10px; box-shadow: 2px 2px 0 #000; z-index: 10;}
-    #ui label { display:block; font-size:12px; margin:6px 0 2px; }
-    #ui input[type="range"] { width: 220px; }
-    #ui .row { display:flex; gap:8px; align-items:center; margin-top:6px; flex-wrap: wrap; }
-    #ui button { border:1px solid #000; background:#fff; padding:6px 10px; border-radius:8px; cursor:pointer; }
-    #ui button:active { transform: translate(1px,1px); }
-    #hint { position: fixed; bottom: 10px; left: 12px; font-size:12px; color:#222; background: rgba(255,255,255,.85); padding:6px 8px; border:1px solid #000; border-radius: 8px; }
-    #testlog { max-width: 360px; white-space: pre-wrap; font-family: ui-monospace, Menlo, Consolas, monospace; font-size: 11px; border-top: 1px dashed #000; margin-top: 6px; padding-top: 6px; }
-    canvas { display:block; width:100vw; height:100vh; }
-    #fileInput { display:none; }
-  </style>
+  <link rel="stylesheet" href="theme.css">
+
 </head>
-<body>
+<body class="tool-square-tiling-tool-svg-import-export">
   <div id="ui">
     <div class="row">
       <button id="modeDraw">✏️ Draw</button>

--- a/theme.css
+++ b/theme.css
@@ -1,0 +1,1016 @@
+/*
+  Arlo Tools brutalist theme
+  -------------------------------------------------------------------
+  A single monochrome-forward palette shared across every tool.
+  Layout rules stay tool-specific, but colors, borders, and typography
+  draw from the same set of variables so each experiment feels like it
+  belongs to one family.
+*/
+
+:root {
+  color-scheme: light;
+  --arlo-bg: #f5f1e8;
+  --arlo-panel: #fffdf7;
+  --arlo-panel-strong: #efe9de;
+  --arlo-ink: #16130d;
+  --arlo-muted: #5c564d;
+  --arlo-border: #16130d;
+  --arlo-shadow: rgba(22, 19, 13, 0.18);
+  --arlo-accent: #16130d;
+  --arlo-focus: #ff5a36;
+}
+
+*, *::before, *::after {
+  box-sizing: border-box;
+}
+
+html, body {
+  height: 100%;
+}
+
+body {
+  margin: 0;
+  background: var(--arlo-bg);
+  color: var(--arlo-ink);
+  font-family: "Inter", "Avenir Next", "Helvetica Neue", Arial, sans-serif;
+  letter-spacing: 0.01em;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+}
+
+h1, h2, h3, h4, h5, h6 {
+  margin: 0 0 1rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+}
+
+p, ul, ol {
+  margin: 0 0 1rem;
+}
+
+ul, ol {
+  padding-left: 1.5rem;
+}
+
+a {
+  color: var(--arlo-accent);
+  text-decoration: none;
+  border-bottom: 2px solid currentColor;
+}
+
+a:hover {
+  background: var(--arlo-panel-strong);
+}
+
+code, pre {
+  font-family: "IBM Plex Mono", "SFMono-Regular", Menlo, Consolas, monospace;
+  background: var(--arlo-panel-strong);
+  border: 2px solid var(--arlo-border);
+  padding: 0.15rem 0.35rem;
+}
+
+.kbd {
+  display: inline-block;
+  padding: 0.15rem 0.4rem;
+  margin: 0 0.15rem;
+  border: 2px solid var(--arlo-border);
+  background: var(--arlo-panel);
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+button,
+input[type="button"],
+input[type="submit"],
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+  padding: 0.55rem 0.9rem;
+  font: inherit;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--arlo-ink);
+  background: var(--arlo-panel);
+  border: 2px solid var(--arlo-border);
+  box-shadow: 6px 6px 0 var(--arlo-shadow);
+  cursor: pointer;
+  transition: transform 0.1s ease, box-shadow 0.1s ease, background 0.1s ease;
+}
+
+button:hover,
+input[type="button"]:hover,
+input[type="submit"]:hover,
+.btn:hover {
+  transform: translate(-2px, -2px);
+  box-shadow: 8px 8px 0 var(--arlo-shadow);
+  background: var(--arlo-panel-strong);
+}
+
+button:focus-visible,
+input:focus-visible,
+select:focus-visible,
+textarea:focus-visible,
+.btn:focus-visible {
+  outline: 3px solid var(--arlo-focus);
+  outline-offset: 2px;
+}
+
+button:disabled,
+input:disabled,
+select:disabled,
+textarea:disabled,
+.btn[disabled] {
+  opacity: 0.6;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+input,
+select,
+textarea {
+  font: inherit;
+  letter-spacing: 0.02em;
+  background: var(--arlo-panel);
+  color: var(--arlo-ink);
+  border: 2px solid var(--arlo-border);
+  padding: 0.4rem 0.6rem;
+  border-radius: 0;
+  min-width: 3rem;
+  box-shadow: 4px 4px 0 var(--arlo-shadow);
+}
+
+input[type="range"] {
+  width: 100%;
+  min-width: 120px;
+  background: transparent;
+  box-shadow: none;
+  accent-color: var(--arlo-ink);
+}
+
+input[type="color"] {
+  padding: 0.1rem;
+  height: 2.25rem;
+}
+
+input[type="checkbox"],
+input[type="radio"] {
+  width: 1.1rem;
+  height: 1.1rem;
+  margin: 0 0.4rem 0 0;
+  vertical-align: middle;
+  accent-color: var(--arlo-ink);
+  box-shadow: none;
+  border: 2px solid var(--arlo-border);
+}
+
+label {
+  font-size: 0.9rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--arlo-muted);
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+label.inline {
+  display: inline-flex;
+}
+
+.muted,
+label .muted,
+.muted span {
+  color: var(--arlo-muted);
+  font-size: 0.85rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+canvas,
+svg,
+video {
+  border: 2px solid var(--arlo-border);
+  background: var(--arlo-panel);
+  box-shadow: 10px 10px 0 var(--arlo-shadow);
+  max-width: 100%;
+}
+
+table {
+  border-collapse: collapse;
+  width: 100%;
+  background: var(--arlo-panel);
+  border: 2px solid var(--arlo-border);
+  box-shadow: 8px 8px 0 var(--arlo-shadow);
+}
+
+table th,
+table td {
+  padding: 0.6rem;
+  border: 2px solid var(--arlo-border);
+  text-align: center;
+}
+
+table th {
+  background: var(--arlo-panel-strong);
+  font-weight: 600;
+}
+
+.controls,
+.toolbar,
+.panel,
+.group,
+section,
+aside,
+legend,
+fieldset,
+.details-panel,
+.sidebar,
+.info-box,
+header,
+footer {
+  background: var(--arlo-panel);
+  border: 2px solid var(--arlo-border);
+  box-shadow: 12px 12px 0 var(--arlo-shadow);
+  padding: 1.25rem;
+}
+
+.controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+  align-items: flex-start;
+}
+
+.control-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  min-width: 180px;
+}
+
+.button-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: center;
+  background: var(--arlo-panel);
+  border: 2px solid var(--arlo-border);
+  box-shadow: 8px 8px 0 var(--arlo-shadow);
+  padding: 0.75rem 1rem;
+}
+
+.wrap {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  background: var(--arlo-panel-strong);
+  border: 2px solid var(--arlo-border);
+  padding: 1rem;
+  box-shadow: 8px 8px 0 var(--arlo-shadow);
+}
+
+.alert {
+  background: var(--arlo-panel-strong);
+  border: 2px solid var(--arlo-border);
+  padding: 0.75rem 1rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.placeholder {
+  border: 2px dashed var(--arlo-border);
+  padding: 2rem;
+  text-align: center;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--arlo-muted);
+}
+
+.spacer {
+  flex: 1 1 auto;
+}
+
+.transport-label {
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--arlo-muted);
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.25rem 0.65rem;
+  border: 2px solid var(--arlo-border);
+  background: var(--arlo-panel);
+  font-size: 0.75rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.badge.pass {
+  background: var(--arlo-panel-strong);
+}
+
+.badge.fail {
+  background: var(--arlo-bg);
+}
+
+.pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.25rem 0.6rem;
+  border: 2px solid var(--arlo-border);
+  background: var(--arlo-panel-strong);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.legend {
+  margin: 1rem 0;
+}
+
+details {
+  background: var(--arlo-panel);
+  border: 2px solid var(--arlo-border);
+  box-shadow: 10px 10px 0 var(--arlo-shadow);
+  padding: 1rem 1.25rem;
+}
+
+details > summary {
+  cursor: pointer;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+details > summary::-webkit-details-marker {
+  display: none;
+}
+
+details > summary::before {
+  content: "▸";
+  display: inline-block;
+  transition: transform 0.2s ease;
+}
+
+details[open] > summary::before {
+  transform: rotate(90deg);
+}
+
+fieldset {
+  border: 2px solid var(--arlo-border);
+  margin: 0 0 1rem;
+}
+
+img {
+  max-width: 100%;
+  border: 2px solid var(--arlo-border);
+  box-shadow: 8px 8px 0 var(--arlo-shadow);
+}
+
+/* ---------- Hub (index.html) ---------- */
+
+body.tool-index {
+  display: grid;
+  grid-template-columns: minmax(260px, 320px) 1fr;
+  min-height: 100vh;
+}
+
+body.tool-index aside.sidebar {
+  position: sticky;
+  top: 0;
+  align-self: flex-start;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  padding: 2rem 1.75rem;
+}
+
+body.tool-index aside.sidebar h1 {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  font-size: 1rem;
+  margin-bottom: 0.25rem;
+}
+
+body.tool-index aside.sidebar h1 span {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.4rem;
+  height: 2.4rem;
+  background: var(--arlo-ink);
+  color: var(--arlo-panel);
+  font-weight: 700;
+  border: 2px solid var(--arlo-border);
+  box-shadow: 6px 6px 0 var(--arlo-shadow);
+}
+
+body.tool-index .search-wrapper {
+  position: relative;
+}
+
+body.tool-index .search-wrapper svg {
+  position: absolute;
+  left: 0.75rem;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 1.1rem;
+  height: 1.1rem;
+  fill: var(--arlo-muted);
+}
+
+body.tool-index input[type="search"] {
+  width: 100%;
+  padding-left: 2.5rem;
+  box-shadow: none;
+}
+
+body.tool-index #tool-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+body.tool-index #tool-list button {
+  justify-content: flex-start;
+  width: 100%;
+}
+
+body.tool-index #tool-list button[aria-selected="true"] {
+  background: var(--arlo-panel-strong);
+}
+
+body.tool-index main {
+  padding: 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+body.tool-index .toolbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+body.tool-index .frame-container {
+  flex: 1;
+  display: flex;
+  border: 2px solid var(--arlo-border);
+  box-shadow: 16px 16px 0 var(--arlo-shadow);
+  background: var(--arlo-panel);
+}
+
+body.tool-index iframe {
+  border: none;
+  flex: 1;
+  width: 100%;
+  min-height: 70vh;
+  background: var(--arlo-panel);
+}
+
+@media (max-width: 960px) {
+  body.tool-index {
+    grid-template-columns: 1fr;
+  }
+
+  body.tool-index aside.sidebar {
+    position: static;
+    order: -1;
+  }
+}
+
+/* ---------- Tool-specific layout rules ---------- */
+
+body[class^="tool-"]:not(.tool-index) {
+  padding: 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+body[class^="tool-"] > script {
+  display: none;
+}
+
+body.tool-3-d-color-space-organizer-collapsible-legend-updated-html header {
+  position: sticky;
+  top: 1.5rem;
+  z-index: 10;
+}
+
+body.tool-3-d-color-space-organizer-collapsible-legend-updated-html .bar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem 1.5rem;
+  align-items: flex-end;
+}
+
+body.tool-3-d-color-space-organizer-collapsible-legend-updated-html .title {
+  font-size: 1rem;
+  letter-spacing: 0.12em;
+  font-weight: 700;
+}
+
+body.tool-3-d-color-space-organizer-collapsible-legend-updated-html .controls {
+  gap: 1rem;
+}
+
+body.tool-3-d-color-space-organizer-collapsible-legend-updated-html .controls label {
+  flex-direction: column;
+  align-items: flex-start;
+  color: var(--arlo-ink);
+}
+
+body.tool-3-d-color-space-organizer-collapsible-legend-updated-html .controls input,
+body.tool-3-d-color-space-organizer-collapsible-legend-updated-html .controls select {
+  width: 140px;
+}
+
+body.tool-3-d-color-space-organizer-collapsible-legend-updated-html .progress-wrap {
+  margin-top: 1rem;
+  height: 0.6rem;
+  background: var(--arlo-panel-strong);
+  border: 2px solid var(--arlo-border);
+  box-shadow: 4px 4px 0 var(--arlo-shadow);
+}
+
+body.tool-3-d-color-space-organizer-collapsible-legend-updated-html .progress {
+  height: 100%;
+  width: 0;
+  background: var(--arlo-ink);
+  transition: width 0.2s ease;
+}
+
+body.tool-3-d-color-space-organizer-collapsible-legend-updated-html main {
+  display: grid;
+  gap: 1.5rem;
+}
+
+body.tool-3-d-color-space-organizer-collapsible-legend-updated-html #view3d,
+body.tool-3-d-color-space-organizer-collapsible-legend-updated-html #stage2d {
+  min-height: 480px;
+  background: var(--arlo-panel);
+  border: 2px solid var(--arlo-border);
+  box-shadow: 14px 14px 0 var(--arlo-shadow);
+  position: relative;
+}
+
+body.tool-3-d-color-space-organizer-collapsible-legend-updated-html #stage2d {
+  display: none;
+}
+
+body.tool-3-d-color-space-organizer-collapsible-legend-updated-html .legend .row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+}
+
+body.tool-3-d-color-space-organizer-collapsible-legend-updated-html footer {
+  font-size: 0.85rem;
+  color: var(--arlo-muted);
+}
+
+body.tool-3-d-color-space-organizer-collapsible-legend-updated-html .tests {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 0.75rem;
+}
+
+/* Audio spectrogram */
+
+body.tool-audio-spectrogram-tool {
+  align-items: center;
+  text-align: center;
+}
+
+body.tool-audio-spectrogram-tool #sidebar {
+  position: fixed;
+  top: 2rem;
+  left: 2rem;
+  bottom: 2rem;
+  width: min(320px, 85vw);
+  overflow-y: auto;
+  display: none;
+  flex-direction: column;
+  gap: 1rem;
+  background: var(--arlo-panel);
+  border: 2px solid var(--arlo-border);
+  box-shadow: 12px 12px 0 var(--arlo-shadow);
+  text-align: left;
+  padding: 1.5rem;
+  z-index: 20;
+}
+
+body.tool-audio-spectrogram-tool .sidebar-close {
+  align-self: flex-end;
+}
+
+body.tool-audio-spectrogram-tool .help-button {
+  position: fixed;
+  top: 1.5rem;
+  left: 1.5rem;
+  z-index: 15;
+}
+
+body.tool-audio-spectrogram-tool canvas {
+  margin-top: 1rem;
+  width: min(960px, 95vw);
+  height: auto;
+}
+
+/* Brutalist mind map */
+
+body.tool-brutalist-mind-map-scaled {
+  display: block;
+  padding: 0;
+  overflow: hidden;
+}
+
+body.tool-brutalist-mind-map-scaled #ui {
+  position: fixed;
+  top: 1.5rem;
+  left: 1.5rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  background: var(--arlo-panel);
+  border: 2px solid var(--arlo-border);
+  box-shadow: 12px 12px 0 var(--arlo-shadow);
+  z-index: 20;
+}
+
+body.tool-brutalist-mind-map-scaled canvas {
+  display: block;
+  width: 100vw;
+  height: 100vh;
+  box-shadow: none;
+  border: none;
+  background: var(--arlo-bg);
+}
+
+/* Chisel-tip pen */
+
+body.tool-chisel-tip-pen-drawing-tool-standalone-html {
+  display: block;
+  padding: 0;
+}
+
+body.tool-chisel-tip-pen-drawing-tool-standalone-html .app {
+  display: grid;
+  grid-template-columns: minmax(280px, 360px) 1fr;
+  grid-template-rows: auto 1fr;
+  min-height: 100vh;
+}
+
+body.tool-chisel-tip-pen-drawing-tool-standalone-html header {
+  grid-column: 1 / -1;
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  position: sticky;
+  top: 0;
+  z-index: 20;
+}
+
+body.tool-chisel-tip-pen-drawing-tool-standalone-html header h1 {
+  margin: 0;
+  font-size: 1rem;
+}
+
+body.tool-chisel-tip-pen-drawing-tool-standalone-html .toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+body.tool-chisel-tip-pen-drawing-tool-standalone-html .side {
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  border-right: 2px solid var(--arlo-border);
+  box-shadow: 12px 0 0 var(--arlo-shadow);
+  background: var(--arlo-panel);
+}
+
+body.tool-chisel-tip-pen-drawing-tool-standalone-html .group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  background: var(--arlo-panel-strong);
+  border: 2px solid var(--arlo-border);
+  padding: 1rem;
+  box-shadow: 8px 8px 0 var(--arlo-shadow);
+}
+
+body.tool-chisel-tip-pen-drawing-tool-standalone-html .group h3 {
+  margin: 0;
+  font-size: 0.9rem;
+}
+
+body.tool-chisel-tip-pen-drawing-tool-standalone-html .row {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+body.tool-chisel-tip-pen-drawing-tool-standalone-html .row-spaced {
+  justify-content: space-between;
+}
+
+body.tool-chisel-tip-pen-drawing-tool-standalone-html .help {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--arlo-muted);
+}
+
+body.tool-chisel-tip-pen-drawing-tool-standalone-html .swatch {
+  width: 36px;
+  height: 36px;
+  border: 2px solid var(--arlo-border);
+  box-shadow: 6px 6px 0 var(--arlo-shadow);
+}
+
+body.tool-chisel-tip-pen-drawing-tool-standalone-html canvas {
+  width: 100%;
+  height: 100%;
+  border: none;
+  box-shadow: none;
+}
+
+body.tool-chisel-tip-pen-drawing-tool-standalone-html .app main,
+body.tool-chisel-tip-pen-drawing-tool-standalone-html .app .canvas-wrap {
+  position: relative;
+  background: var(--arlo-bg);
+}
+
+/* Graded Game of Life */
+
+body.tool-graded-game-of-life {
+  align-items: center;
+}
+
+body.tool-graded-game-of-life canvas {
+  width: min(90vw, 640px);
+  height: auto;
+}
+
+body.tool-graded-game-of-life .controls {
+  width: min(90vw, 960px);
+  justify-content: space-between;
+}
+
+body.tool-graded-game-of-life .controls > div {
+  flex: 1;
+  min-width: 220px;
+}
+
+body.tool-graded-game-of-life h4 {
+  margin-bottom: 0.5rem;
+}
+
+/* Less circle-centric fractal */
+
+body.tool-less-circle-centric-fractal-1 {
+  align-items: center;
+}
+
+body.tool-less-circle-centric-fractal-1 canvas {
+  width: min(95vw, 820px);
+  height: auto;
+}
+
+/* Lissajous grid */
+
+body.tool-lissajous-figure-grid {
+  display: grid;
+  gap: 1.5rem;
+}
+
+body.tool-lissajous-figure-grid #table-container {
+  overflow: auto;
+  border: 2px solid var(--arlo-border);
+  box-shadow: 14px 14px 0 var(--arlo-shadow);
+  background: var(--arlo-panel);
+}
+
+body.tool-lissajous-figure-grid #sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  max-width: 320px;
+}
+
+body.tool-lissajous-figure-grid #sidebar button {
+  width: fit-content;
+}
+
+/* Medieval border generator */
+
+body.tool-medieval-border-generator-geometric-tiling-v-2 .controls {
+  width: min(90vw, 1024px);
+}
+
+body.tool-medieval-border-generator-geometric-tiling-v-2 canvas {
+  width: min(95vw, 960px);
+  height: auto;
+}
+
+/* MIDI to neumes */
+
+body.tool-midi-neumes-converter-single-file-html {
+  gap: 1rem;
+}
+
+body.tool-midi-neumes-converter-single-file-html textarea {
+  width: min(90vw, 720px);
+  min-height: 200px;
+}
+
+body.tool-midi-neumes-converter-single-file-html .controls {
+  width: min(90vw, 720px);
+}
+
+/* Particle tree */
+
+body.tool-particle-tree-zoom-scroll {
+  align-items: center;
+}
+
+body.tool-particle-tree-zoom-scroll canvas {
+  width: min(95vw, 960px);
+  height: auto;
+}
+
+/* Pixel row glitcher */
+
+body.tool-pixel-row-glitcher {
+  align-items: center;
+}
+
+body.tool-pixel-row-glitcher canvas {
+  width: min(95vw, 960px);
+  height: auto;
+}
+
+/* Random I Heart */
+
+body.tool-random-i-heart {
+  align-items: center;
+}
+
+body.tool-random-i-heart canvas {
+  width: min(90vw, 640px);
+  height: auto;
+}
+
+/* Recursive vector fractal lab */
+
+body.tool-recursive-vector-fractal-lab-standalone-html-2 {
+  display: block;
+  padding: 0;
+}
+
+body.tool-recursive-vector-fractal-lab-standalone-html-2 .app {
+  display: grid;
+  grid-template-columns: minmax(260px, 320px) 1fr;
+  grid-template-rows: auto 1fr;
+  min-height: 100vh;
+}
+
+body.tool-recursive-vector-fractal-lab-standalone-html-2 header {
+  grid-column: 1 / -1;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+  position: sticky;
+  top: 0;
+  z-index: 15;
+}
+
+body.tool-recursive-vector-fractal-lab-standalone-html-2 header .spacer {
+  flex: 1;
+}
+
+body.tool-recursive-vector-fractal-lab-standalone-html-2 .grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 320px;
+  position: relative;
+}
+
+body.tool-recursive-vector-fractal-lab-standalone-html-2 .left {
+  position: relative;
+  background: var(--arlo-bg);
+}
+
+body.tool-recursive-vector-fractal-lab-standalone-html-2 .wrap {
+  position: relative;
+  width: 100%;
+  height: 100%;
+}
+
+body.tool-recursive-vector-fractal-lab-standalone-html-2 canvas,
+body.tool-recursive-vector-fractal-lab-standalone-html-2 .overlay {
+  border: none;
+  box-shadow: none;
+}
+
+body.tool-recursive-vector-fractal-lab-standalone-html-2 .right {
+  background: var(--arlo-panel);
+  border-left: 2px solid var(--arlo-border);
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  max-height: calc(100vh - 4rem);
+  overflow-y: auto;
+}
+
+body.tool-recursive-vector-fractal-lab-standalone-html-2 section {
+  background: var(--arlo-panel-strong);
+  border: 2px solid var(--arlo-border);
+  padding: 1rem;
+  box-shadow: 8px 8px 0 var(--arlo-shadow);
+}
+
+body.tool-recursive-vector-fractal-lab-standalone-html-2 .row {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+  justify-content: space-between;
+}
+
+body.tool-recursive-vector-fractal-lab-standalone-html-2 .cols2 {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+body.tool-recursive-vector-fractal-lab-standalone-html-2 .full-span {
+  grid-column: 1 / -1;
+}
+
+/* Spectrogram glitch posteffects */
+
+body.tool-spectrogram-glitch-posteffects-1 {
+  align-items: center;
+}
+
+body.tool-spectrogram-glitch-posteffects-1 canvas {
+  width: min(95vw, 960px);
+  height: auto;
+}
+
+/* Square tiling tool */
+
+body.tool-square-tiling-tool-svg-import-export .controls {
+  width: min(90vw, 960px);
+}
+
+body.tool-square-tiling-tool-svg-import-export canvas {
+  width: min(95vw, 960px);
+  height: auto;
+}
+
+@media (max-width: 840px) {
+  body.tool-chisel-tip-pen-drawing-tool-standalone-html .app,
+  body.tool-recursive-vector-fractal-lab-standalone-html-2 .app {
+    grid-template-columns: 1fr;
+  }
+
+  body.tool-chisel-tip-pen-drawing-tool-standalone-html .side,
+  body.tool-recursive-vector-fractal-lab-standalone-html-2 .right {
+    position: static;
+    max-height: none;
+  }
+
+  body.tool-recursive-vector-fractal-lab-standalone-html-2 .grid {
+    grid-template-columns: 1fr;
+  }
+}
+


### PR DESCRIPTION
## Summary
- rebuild `theme.css` around a single brutalist palette shared across the hub and every embedded tool
- add reusable component rules and per-tool layout tweaks so forms, panels, and canvases all inherit the same background and border treatments
- refresh the hub sidebar and viewer styling to match the new monochrome-forward design

## Testing
- Not run (static content only)

------
https://chatgpt.com/codex/tasks/task_e_68d9fc248880832a85ee48d834362b64